### PR TITLE
Fix tests after merge

### DIFF
--- a/backend/src/dailyinsightai/ai_integration.py
+++ b/backend/src/dailyinsightai/ai_integration.py
@@ -5,9 +5,33 @@ Handles communication with the OpenAI API.
 Defines the `generate_insight` function which takes user input and returns a generated insight using the Chat API.
 """
 
-import openai
+try:
+    import openai
+except ModuleNotFoundError:  # pragma: no cover - openai may not be installed in CI
+    from types import SimpleNamespace
+
+    class DummyClient:
+        """Fallback OpenAI client used when openai package is unavailable."""
+
+        def __init__(self, *_, **__):
+            pass
+
+        class chat:
+            class completions:
+                @staticmethod
+                def create(*_, **__):
+                    raise RuntimeError("OpenAI package not installed")
+
+    class OpenAIError(Exception):
+        """Raised when OpenAI operations fail with no library installed."""
+
+    openai = SimpleNamespace(OpenAI=DummyClient, OpenAIError=OpenAIError)
 import os
-from dotenv import load_dotenv
+try:
+    from dotenv import load_dotenv
+except ModuleNotFoundError:  # pragma: no cover - python-dotenv optional in CI
+    def load_dotenv(*_, **__):
+        return False
 
 load_dotenv()
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))

--- a/backend/tests/test_basic.py
+++ b/backend/tests/test_basic.py
@@ -37,8 +37,8 @@ def test_generate_insight_returns_text(mock_openai_class):
 @patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"})
 @patch("dailyinsightai.ai_integration.openai.OpenAI")
 def test_generate_insight_handles_openai_error(mock_openai_class):
-    from dailyinsightai.ai_integration import generate_insight
-    from openai import OpenAIError
+    from dailyinsightai.ai_integration import generate_insight, openai
+    OpenAIError = getattr(openai, "OpenAIError", Exception)
 
     # Simulate OpenAI client raising an error
     mock_client = MagicMock()


### PR DESCRIPTION
## Summary
- add a conftest to expose backend modules on PYTHONPATH
- stub out optional OpenAI and dotenv imports so tests run without those deps
- adjust failing test to use fallback OpenAIError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829f590ac88326ae0eb66d0f95dbd8