### PR TITLE
Fix CI for monorepo structure

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -25,9 +25,11 @@ jobs:
         curl -sSL https://install.python-poetry.org | python3 -
 
     - name: Install dependencies
+      working-directory: ./backend
       run: |
         poetry install
 
     - name: Run tests
+      working-directory: ./backend
       run: |
         poetry run pytest

--- a/README.md
+++ b/README.md
@@ -61,20 +61,10 @@ cd dailyinsightai
 # Navigate to backend directory
 cd backend
 
-# Create virtual environment
-python -m venv venv
+# Install Python dependencies using Poetry
+poetry install
 
-# Activate virtual environment
-# On macOS/Linux:
-source venv/bin/activate
-# On Windows:
-# venv\Scripts\activate
-
-# Install dependencies
-pip install -r requirements.txt
-
-# Create .env file with your credentials
-# Copy .env.example to .env and fill in your values
+# Create `.env` with your credentials
 cp .env.example .env
 
 # Run the backend server
@@ -104,7 +94,8 @@ The frontend will be available at http://localhost:3000 and the backend API at h
 ### 4. Run the CLI App (Legacy)
 
 ```bash
-# From the root directory
+# From the backend directory
+cd backend
 poetry install
 poetry run python -m dailyinsightai.main
 ```
@@ -133,16 +124,18 @@ We love community contributions! Please follow these guidelines to keep the proj
 
 2. Install development dependencies and pre‑commit hooks:
 
-   ```bash
-   poetry install --with dev
-   pre-commit install
-   ```
+```bash
+cd backend
+poetry install --with dev
+pre-commit install
+```
 
 3. Make your changes and run lint + tests locally:
 
-   ```bash
-   poetry run task lint && poetry run pytest
-   ```
+```bash
+cd backend
+poetry run task lint && poetry run pytest
+```
 
 4. Commit using Conventional Commits and push your branch:
 

--- a/backend/tests/test_basic.py
+++ b/backend/tests/test_basic.py
@@ -1,38 +1,32 @@
-"""
-test_basic.py
+"""test_basic.py
 
 Contains a basic test case to validate AI integration by checking that `generate_insight` returns non-empty output.
 """
 from unittest.mock import patch, MagicMock
 import os
 
+
 @patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"})
 @patch("dailyinsightai.ai_integration.openai.OpenAI")
 def test_generate_insight_returns_text(mock_openai_class):
     from dailyinsightai.ai_integration import generate_insight
 
-    # Create a mock message object
     mock_message = MagicMock()
     mock_message.content = "Mocked insight"
-
-    # Create a mock choice that contains the mock message
     mock_choice = MagicMock()
     mock_choice.message = mock_message
-
-    # Create a mock response with choices list
     mock_response = MagicMock()
     mock_response.choices = [mock_choice]
 
-    # Set up the nested client.chat.completions.create() call
     mock_create = MagicMock(return_value=mock_response)
     mock_completions = MagicMock(create=mock_create)
     mock_chat = MagicMock(completions=mock_completions)
     mock_client = MagicMock(chat=mock_chat)
-
     mock_openai_class.return_value = mock_client
 
     result = generate_insight("This is a test.")
     assert "Mocked insight" in result
+
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"})
 @patch("dailyinsightai.ai_integration.openai.OpenAI")
@@ -40,7 +34,6 @@ def test_generate_insight_handles_openai_error(mock_openai_class):
     from dailyinsightai.ai_integration import generate_insight
     from openai import OpenAIError
 
-    # Simulate OpenAI client raising an error
     mock_client = MagicMock()
     mock_client.chat.completions.create.side_effect = OpenAIError("Simulated API failure")
     mock_openai_class.return_value = mock_client


### PR DESCRIPTION
## Summary
- update CI workflow to run poetry inside `backend`
- fix `tests/test_basic.py` formatting
- update README instructions for new backend path

## Testing
- `poetry install` *(fails: All attempts to connect to pypi.org failed)*
- `poetry run pytest` *(fails: ModuleNotFoundError for `dailyinsightai`)*

------
https://chatgpt.com/codex/tasks/task_e_6882a1c3ff988326a407fbf1a1c13992